### PR TITLE
Merge :source-paths into :resource-paths before building jar.

### DIFF
--- a/src/adzerk/bootlaces.clj
+++ b/src/adzerk/bootlaces.clj
@@ -24,7 +24,7 @@
 
 (defn bootlaces!
   [version & {:keys [dev-dependencies]}]
-  (merge-env! :resource-paths #{"src"})
+  (merge-env! :resource-paths (get-env :source-paths))
   (when dev-dependencies
     (->> dev-dependencies
          assert-edn-resource


### PR DESCRIPTION
Fixes issue #9 where source-paths was hardcoded to #{"src"}.