### PR TITLE
add flag to not mess with paths

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -6,7 +6,7 @@
 (require '[boot.git :refer [last-commit]]
          '[adzerk.bootlaces :refer :all])
 
-(def +version+ "0.1.12")
+(def +version+ "0.1.13")
 
 (bootlaces! +version+)
 

--- a/src/adzerk/bootlaces.clj
+++ b/src/adzerk/bootlaces.clj
@@ -19,8 +19,9 @@
       read-string))
 
 (defn bootlaces!
-  [version & {:keys [dev-dependencies]}]
-  (merge-env! :resource-paths #{"src"})
+  [version & {:keys [dev-dependencies dont-modify-paths?]}]
+  (when-not dont-modify-paths?
+    (merge-env! :resource-paths #{"src"}))
   (when dev-dependencies
     (->> dev-dependencies
          assert-edn-resource


### PR DESCRIPTION
Solution to similar problems as in #10 and #7 while staying fully
backwards compatible.

          (bootlaces! version :dont-modify-paths? true)

At some point we might want to remove this again and just drop the handling completely but probably it's not worth breaking people's builds for that.