### PR TITLE
remove hardcoded referenc to src dir

### DIFF
--- a/src/adzerk/bootlaces.clj
+++ b/src/adzerk/bootlaces.clj
@@ -21,7 +21,7 @@
 (defn bootlaces!
   [version & {:keys [dev-dependencies dont-modify-paths?]}]
   (when-not dont-modify-paths?
-    (merge-env! :resource-paths #{"src"}))
+    (merge-env! :resource-paths (get-env :soure-paths)))
   (when dev-dependencies
     (->> dev-dependencies
          assert-edn-resource


### PR DESCRIPTION
i assume there must be some reason the directory "src" was hardcoded, but it seems this should be obtained from the boot environment.  the hoplon/ui build broke when i moved the sources from "src" to "lib/src"; this patch fixes it.